### PR TITLE
C Buttons Icon Fix

### DIFF
--- a/assembly/c/Sprite.c
+++ b/assembly/c/Sprite.c
@@ -2,6 +2,7 @@
 #include "Sprite.h"
 #include "Util.h"
 
+extern uint8_t CFG_WS_ENABLED;
 extern char DPAD_TEXTURE;
 #define DpadTextureRaw ((u8*)&DPAD_TEXTURE)
 
@@ -93,6 +94,9 @@ Sprite* Sprite_GetItemTexturesSprite(void) {
 }
 
 void Sprite_Init(void) {
+	if (CFG_WS_ENABLED)
+        gSetupDb[2] = gsDPSetScissor(G_SC_NON_INTERLACE, 0, 0, SCREEN_WIDTH + 104, SCREEN_HEIGHT);
+	
     gSpriteDpad.buf = DpadTextureRaw;
 
     // Allocate space for item textures


### PR DESCRIPTION
When in WS mode, allows Redux to cover the extra added width so that the C Button Icons no longer get clamped away.